### PR TITLE
Expect .so not .dylib on macos

### DIFF
--- a/kdtree/CMakeLists.txt
+++ b/kdtree/CMakeLists.txt
@@ -26,8 +26,6 @@ install(
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib)
 
-# @todo - osx link options "-install_name @rpath/libkdtree.dylib"
-
 # Construct source groups for IDEs
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/include PREFIX include FILES ${KDTREE_INCLUDE})
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/src PREFIX src FILES ${KDTREE_SRC})

--- a/navmeshBuilder/CMakeLists.txt
+++ b/navmeshBuilder/CMakeLists.txt
@@ -72,8 +72,6 @@ install(
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib)
 
-# @todo osx "-install_name @rpath/libnavmesh.dylib"
-
 # Construct source groups for IDEs
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/include PREFIX include FILES ${NAVMESH_INCLUDE})
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/src PREFIX src FILES ${NAVMESH_SRC})

--- a/rvo2AI/CMakeLists.txt
+++ b/rvo2AI/CMakeLists.txt
@@ -15,7 +15,6 @@ set(RVO2AI_INCLUDE_DIRS
 add_library(rvo2dAI MODULE ${RVO2AI_SRC} ${RVO2AI_INCLUDE})
 target_include_directories(rvo2dAI PRIVATE ${RVO2AI_INCLUDE_DIRS})
 target_link_libraries(rvo2dAI steerlib util)
-
 install(
   TARGETS rvo2dAI
   RUNTIME DESTINATION bin

--- a/steerlib/src/SimulationEngine.cpp
+++ b/steerlib/src/SimulationEngine.cpp
@@ -897,7 +897,7 @@ SteerLib::ModuleMetaInformation * SimulationEngine::_loadModule(const std::strin
 		std::string extension = ".dll";
 		std::string libstr = "";
 #elif __APPLE__
-		std::string extension = ".dylib";
+		std::string extension = ".so";
 		std::string libstr = "lib";
 #else
 		std::string extension = ".so";


### PR DESCRIPTION
Change the expected dynamic module extension from .dylib to .so on macos

It could be extended to support either extension, but given CMake is now the only build system this isn't required afaik.

If this now works as expected this should resolve #15.